### PR TITLE
fix: 修复packages/compnens 'rimraf dist'为'rimraf lib'

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "build:file": "node build/bin/build-entry.js",
-    "clean": "rimraf dist",
+    "clean": "rimraf lib",
     "build": "npm run clean && npm run build:file && webpack --config build/webpack.conf.js && webpack --config build/webpack.common.js && webpack --config build/webpack.component.js",
     "lint": "eslint  lib/**/* build/**/* --quiet",
     "test": "echo \"Error: run tests from root\" && exit 1"


### PR DESCRIPTION
之前packages/componens打包到的目录是lib，而删除的目录是dist，不能实现重新打包后完全重写lib目录，所以修改删除的目录为lib